### PR TITLE
feat: indent till next tabStop ...

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ const indentSelection = (selection: vscode.Selection, textEditor: vscode.TextEdi
 	}
 
 	// detect where indentation ends -> indent line if cursor is at indentation, otherwise
-	//                                  insert `textEditor.options.tabSize` amount of spaces
+	//                                  insert spaces to reach tabstop as per `textEditor.options.tabSize`
 
 	const indentEndCharacter: number = textEditor.document
 		.lineAt(selection.active)
@@ -95,9 +95,13 @@ const indentSelection = (selection: vscode.Selection, textEditor: vscode.TextEdi
 	//          const x:   number = ...;
 	//          const bar: number = ...;
 
+	const tillNextStop: number = textEditor.options.tabSize - (
+		(selection.active.character - indentEndCharacter) % textEditor.options.tabSize
+	)
+
 	const str: string = ((selection.active.character <= indentEndCharacter)
 	                     ? "\t"
-	                     : " ".repeat(textEditor.options.tabSize as number));
+	                     : " ".repeat(tillNextStop));
 
 	edit.insert(selection.active, str);
 };


### PR DESCRIPTION
Problem: Currently a constant amount of spaces is inserted.
        This makes it unsuitable for use as alignment
Solution: Insert only enough amount of spaces so that 
        cursor reaches next tab stop. 
        
        Example:
        textEditor.options.tabSize = 5,
        selection.active.character = 23, (23 chars in line)
        indentEndCharacter = 2 (2 tabs in start)

        here,
            number of cols <- (23 - 2) + (2 * 5) = 31
        so,
            tillNextStop <- 5 - ((23 - 2) % 5) = 4
        => 4 spaces should be inserted

# Pull Request #

* [x] Feature/Addition implementation
* [ ] Adjustment/Revision/Improvement implementation
* [x] Bug/Error fix
  * [ ] Typo / Grammar Mistake Fix
* [ ] Internal Refactor or Cleanup (e.g.: formatting fixes)
* [ ] Other: _____

Closes Issue(s): _____

## Summary ##

Describe your changes in detail.
